### PR TITLE
Fixing typo on boolen field 'multilingual'

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,6 +1,6 @@
 [book]
 authors = ["el-tipton"]
 language = "en"
-multilingual = False
+multilingual = false
 src = "src"
 title = "HBFA-FL: Host-Based Firmware Analyzer - Fuzzing Lite"


### PR DESCRIPTION
Fixing a typo in toml file for mdbook build.