### PR TITLE
Add oss-fuzz TestBmpSupportLib.options

### DIFF
--- a/oss-fuzz/TestBmpSupportLib.options
+++ b/oss-fuzz/TestBmpSupportLib.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+rss_limit_mb=6000

--- a/oss-fuzz/build.sh
+++ b/oss-fuzz/build.sh
@@ -34,7 +34,7 @@ python $SRC/hbfa-fl/HBFA/UefiHostTestTools/HBFAEnvSetup.py
 
 cp $SRC/hbfa-fl/HBFA/UefiHostFuzzTestPkg/Conf/build_rule.txt $SRC/edk2/Conf/build_rule.txt
 cp $SRC/hbfa-fl/HBFA/UefiHostFuzzTestPkg/Conf/tools_def.txt $SRC/edk2/Conf/tools_def.txt
-cp $SRC/*.options $OUT
+cp $SRC/hbfa-fl/oss-fuzz/*.options $OUT
 
 build_fuzzer "TestBmpSupportLib" \
     "$SRC/hbfa-fl/HBFA/UefiHostFuzzTestCasePkg/TestCase/MdeModulePkg/Library/BaseBmpSupportLib/TestBmpSupportLib.inf" \


### PR DESCRIPTION
We'll store oss-fuzz fuzzer options in the hbfa-fl repo so we don't have to keep updating oss-fuzz repo itself.