### PR TITLE
Disable TestValidateTdxCfv

### DIFF
--- a/HBFA/UefiHostFuzzTestCasePkg/UefiHostFuzzTestCasePkg.dsc
+++ b/HBFA/UefiHostFuzzTestCasePkg/UefiHostFuzzTestCasePkg.dsc
@@ -216,32 +216,32 @@
    RngLib|MdePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
    CcProbeLib|OvmfPkg/Library/CcProbeLib/DxeCcProbeLib.inf
   }
- UefiHostFuzzTestCasePkg/TestCase/OvmfPkg/EmuVariableFvbRuntimeDxe/TestValidateTdxCfv.inf{
-  <LibraryClasses>
-   NULL|OvmfPkg/EmuVariableFvbRuntimeDxe/Fvb.inf
-   UefiRuntimeLib|MdePkg/Library/UefiRuntimeLib/UefiRuntimeLib.inf
-   PlatformFvbLib|OvmfPkg/Library/EmuVariableFvbLib/EmuVariableFvbLib.inf
-   CcProbeLib|OvmfPkg/Library/CcProbeLib/DxeCcProbeLib.inf
-   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
-   BaseLib|MdePkg/Library/BaseLib/BaseLib.inf
-   PeiHardwareInfoLib|OvmfPkg/Library/HardwareInfoLib/PeiHardwareInfoLib.inf
-   RegisterFilterLib|MdePkg/Library/RegisterFilterLibNull/RegisterFilterLibNull.inf
+# UefiHostFuzzTestCasePkg/TestCase/OvmfPkg/EmuVariableFvbRuntimeDxe/TestValidateTdxCfv.inf{
+#  <LibraryClasses>
+#   NULL|OvmfPkg/EmuVariableFvbRuntimeDxe/Fvb.inf
+#   UefiRuntimeLib|MdePkg/Library/UefiRuntimeLib/UefiRuntimeLib.inf
+#   PlatformFvbLib|OvmfPkg/Library/EmuVariableFvbLib/EmuVariableFvbLib.inf
+#   CcProbeLib|OvmfPkg/Library/CcProbeLib/DxeCcProbeLib.inf
+#   PcdLib|MdePkg/Library/DxePcdLib/DxePcdLib.inf
+#   BaseLib|MdePkg/Library/BaseLib/BaseLib.inf
+#   PeiHardwareInfoLib|OvmfPkg/Library/HardwareInfoLib/PeiHardwareInfoLib.inf
+#   RegisterFilterLib|MdePkg/Library/RegisterFilterLibNull/RegisterFilterLibNull.inf
    #UefiCpuLib|UefiCpuPkg/Library/BaseUefiCpuLib/BaseUefiCpuLib.inf
-   LocalApicLib|UefiCpuPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.inf
-   CcExitLib|OvmfPkg/Library/CcExitLib/CcExitLib.inf
-   MemEncryptTdxLib|OvmfPkg/Library/BaseMemEncryptTdxLib/BaseMemEncryptTdxLib.inf
-   MemEncryptSevLib|OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLib.inf
-   CpuLib|MdePkg/Library/BaseCpuLib/BaseCpuLib.inf
-   PciExpressLib|MdePkg/Library/BasePciExpressLib/BasePciExpressLib.inf  
-   PciCf8Lib|MdePkg/Library/BasePciCf8Lib/BasePciCf8Lib.inf
-   TdxLib|MdePkg/Library/TdxLib/TdxLib.inf
-   PciLib|OvmfPkg/Library/DxePciLibI440FxQ35/DxePciLibI440FxQ35.inf
-   MtrrLib|UefiCpuPkg/Library/MtrrLib/MtrrLib.inf
-   QemuFwCfgSimpleParserLib|OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParserLib.inf
-   QemuFwCfgLib|OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgDxeLib.inf
-   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
-   PlatformInitLib|OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
-  }
+#   LocalApicLib|UefiCpuPkg/Library/BaseXApicX2ApicLib/BaseXApicX2ApicLib.inf
+#   CcExitLib|OvmfPkg/Library/CcExitLib/CcExitLib.inf
+#   MemEncryptTdxLib|OvmfPkg/Library/BaseMemEncryptTdxLib/BaseMemEncryptTdxLib.inf
+#   MemEncryptSevLib|OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLib.inf
+#   CpuLib|MdePkg/Library/BaseCpuLib/BaseCpuLib.inf
+#   PciExpressLib|MdePkg/Library/BasePciExpressLib/BasePciExpressLib.inf  
+#   PciCf8Lib|MdePkg/Library/BasePciCf8Lib/BasePciCf8Lib.inf
+#   TdxLib|MdePkg/Library/TdxLib/TdxLib.inf
+#   PciLib|OvmfPkg/Library/DxePciLibI440FxQ35/DxePciLibI440FxQ35.inf
+#   MtrrLib|UefiCpuPkg/Library/MtrrLib/MtrrLib.inf
+#   QemuFwCfgSimpleParserLib|OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParserLib.inf
+#   QemuFwCfgLib|OvmfPkg/Library/QemuFwCfgLib/QemuFwCfgDxeLib.inf
+#   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
+#   PlatformInitLib|OvmfPkg/Library/PlatformInitLib/PlatformInitLib.inf
+#  }
 
  UefiHostFuzzTestCasePkg/TestCase/OvmfPkg/VirtioPciDeviceDxe/TestVirtioPciDevice.inf{
   <LibraryClasses>

--- a/docs/src/harness/includedfuzzharnesses.md
+++ b/docs/src/harness/includedfuzzharnesses.md
@@ -14,7 +14,6 @@ A number of fuzzing test harness cases are included in HBFA-FL. These, test-harn
 | TestFmpAuthenticationLibRsa2048Sha256 | HBFA/UefiHostFuzzTestCasePkg/TestCase/SecurityPkg/Library/FmpAuthenticationLibRsa2048Sha256/TestFmpAuthenticationLibRsa2048Sha256.{c,inf} |
 | TestCapsulePei | HBFA/UefiHostFuzzTestCasePkg/TestCase/MdeModulePkg/Universal/CapsulePei/Common/TestCapsulePei.{c,inf} |
 | TestFileName | HBFA/UefiHostFuzzTestCasePkg/TestCase/MdeModulePkg/Universal/Disk/UdfDxe/TestFileName.{c,inf} |
-| TestValidateTdxCfv | HBFA/UefiHostFuzzTestCasePkg/TestCase/OvmfPkg/EmuVariableFvbRuntimeDxe/TestValidateTdxCfv.{c,inf} |
 | TestTcg2MeasureGptTable | HBFA/UefiHostFuzzTestCasePkg/TestCase/SecurityPkg/Library/DxeTpm2MeasureBootLib/TestTcg2MeasureGptTable.{c,inf} |
 | TestTcg2MeasurePeImage | HBFA/UefiHostFuzzTestCasePkg/TestCase/SecurityPkg/Library/DxeTpm2MeasureBootLib/TestTcg2MeasurePeImage.{c,inf} |
 | TestVirtioPciDevice | HBFA/UefiHostFuzzTestCasePkg/TestCase/OvmfPkg/VirtioPciDeviceDxe/TestVirtioPciDevice.{c,inf} |
@@ -65,5 +64,6 @@ The following fuzzing test-cases are not included in HBFA-FL; however, they are 
 | TestUpdateLockBoxFuzzOffset | HBFA/UefiHostFuzzTestCasePkg/TestCase/MdeModulePkg/Library/SmmLockBoxLib/UpdateLockBoxTestCase/TestUpdateLockBoxFuzzOffset.{c,inf} |
 | TestHobList | HBFA/UefiHostFuzzTestCasePkg/TestCase/OvmfPkg/Library/TdxStartupLib/TestHobList.{c,inf} |
 | TestParseMmioExitInstructions | HBFA/UefiHostFuzzTestCasePkg/TestCase/OvmfPkg/Library/CcExitLib/TestParseMmioExitInstructions.{c,inf} |
+| TestValidateTdxCfv | HBFA/UefiHostFuzzTestCasePkg/TestCase/OvmfPkg/EmuVariableFvbRuntimeDxe/TestValidateTdxCfv.{c,inf} |
 
 [&lt;&lt;](../fuzzing/building.md) Back | Return to [Summary](../SUMMARY.md) | Next [&gt;&gt;](../fuzzing/fuzzingwithAFL.md)


### PR DESCRIPTION
Test no longer builds:
```
Active Platform          = /src/hbfa-fl/HBFA/UefiHostFuzzTestCasePkg/UefiHostFuzzTestCasePkg.dsc
Active Module            = /src/hbfa-fl/HBFA/UefiHostFuzzTestCasePkg/TestCase/MdeModulePkg/Library/BaseBmpSupportLib/TestBmpSupportLib.inf
 
 
build.py...
/src/hbfa-fl/HBFA/UefiHostFuzzTestCasePkg/UefiHostFuzzTestCasePkg.dsc(...): error 4000: Instance of library class [AmdSvsmLib] is not found
	in [/src/edk2/OvmfPkg/Library/BaseMemEncryptSevLib/DxeMemEncryptSevLib.inf] [X64]
	consumed by module [/src/hbfa-fl/HBFA/UefiHostFuzzTestCasePkg/TestCase/OvmfPkg/EmuVariableFvbRuntimeDxe/TestValidateTdxCfv.inf]