### PR TITLE
Fix edk2 coverage build due to changed definition of EFI_PCI_IO_PROTOCOL_IO_MEM 

### DIFF
--- a/HBFA/UefiHostFuzzTestCasePkg/TestStub/VirtioPciDevice10StubLib/VirtioPciDevice10StubLib.c
+++ b/HBFA/UefiHostFuzzTestCasePkg/TestStub/VirtioPciDevice10StubLib/VirtioPciDevice10StubLib.c
@@ -813,9 +813,9 @@ EFIAPI
 PciIoRead (
   IN EFI_PCI_IO_PROTOCOL       *PciIo,
   IN EFI_PCI_IO_PROTOCOL_WIDTH Width,
-  IN UINT16                    Offset,
-  IN UINT16                    Count,
-  IN OUT UINT8                 *Buffer
+  IN UINT32                    Offset,
+  IN UINTN                     Count,
+  IN OUT VOID                  *Buffer
 ) {
   UINT16 Len = 0;
 

--- a/HBFA/UefiHostTestTools/RunLibFuzzer.py
+++ b/HBFA/UefiHostTestTools/RunLibFuzzer.py
@@ -436,8 +436,8 @@ def main():
                   " should start with {}.".format(HBFA_PATH))
             os._exit(0)
     elif not os.path.exists(os.path.join(HBFA_PATH, args.ModuleFile)):
-        print("ModuleFile path: {}".format(os.path.abspath(args.InputSeed))
-              + " does not exist or is not in the relative path for HBFA")
+        print("ModuleFile path: {}".format(args.ModuleFile)
+              + " does not exist or is not in the relative path for HBFA: {}".format(os.path.abspath(HBFA_PATH)))
         os._exit(0)
     else:
         ModuleFilePath = args.ModuleFile


### PR DESCRIPTION
```
/src/hbfa-fl/HBFA/UefiHostFuzzTestCasePkg/TestStub/VirtioPciDevice10StubLib/VirtioPciDevice10StubLib.c:857:19: error: incompatible function pointer types assigning to 'EFI_PCI_IO_PROTOCOL_CONFIG' (aka 'unsigned long long (*)(struct _EFI_PCI_IO_PROTOCOL *, EFI_PCI_IO_PROTOCOL_WIDTH, unsigned int, unsigned long long, void *)') from 'EFI_STATUS (*)(EFI_PCI_IO_PROTOCOL *, EFI_PCI_IO_PROTOCOL_WIDTH, UINT16, UINT16, UINT8 *)' (aka 'unsigned long long (*)(struct _EFI_PCI_IO_PROTOCOL *, EFI_PCI_IO_PROTOCOL_WIDTH, unsigned short, unsigned short, unsigned char *)') [-Wincompatible-function-pointer-types]
  857 |   PciIo->Pci.Read = &PciIoRead;