### PR TITLE
Fix PciIoRead in VirtioPciDeviceStubLib

### DIFF
--- a/HBFA/UefiHostFuzzTestCasePkg/TestStub/VirtioPciDeviceStubLib/VirtioPciDeviceStubLib.c
+++ b/HBFA/UefiHostFuzzTestCasePkg/TestStub/VirtioPciDeviceStubLib/VirtioPciDeviceStubLib.c
@@ -191,8 +191,8 @@ PciIoRead (
   IN EFI_PCI_IO_PROTOCOL       *PciIo,
   IN EFI_PCI_IO_PROTOCOL_WIDTH Width,
   IN UINT8                     BAR_IDX,
-  IN UINT16                    Offset,
-  IN UINT16                    Count,
+  IN UINT64                    Offset,
+  IN UINTN                     Count,
   IN OUT UINT8                 *Buffer
 ) {
   UINT16 Len = 0;


### PR DESCRIPTION
Not sure why this one wasn't causing build failure while the other did but might as well fix this one too.

```
/src/hbfa-fl/HBFA/UefiHostFuzzTestCasePkg/TestStub/VirtioPciDeviceStubLib/VirtioPciDeviceStubLib.c:321:18: error: incompatible function pointer types assigning to 'EFI_PCI_IO_PROTOCOL_IO_MEM' (aka 'unsigned long long (*)(struct _EFI_PCI_IO_PROTOCOL *, EFI_PCI_IO_PROTOCOL_WIDTH, unsigned char, unsigned long long, unsigned long long, void *)') from 'EFI_STATUS (*)(EFI_PCI_IO_PROTOCOL *, EFI_PCI_IO_PROTOCOL_WIDTH, UINT8, UINT16, UINT16, UINT8 *)' (aka 'unsigned long long (*)(struct _EFI_PCI_IO_PROTOCOL *, EFI_PCI_IO_PROTOCOL_WIDTH, unsigned char, unsigned short, unsigned short, unsigned char *)') [-Wincompatible-function-pointer-types]