### PR TITLE
Multiple edk2 bugfixes

### DIFF
--- a/edk2-bugfixes/0001-Fix-MangleFilename.patch
+++ b/edk2-bugfixes/0001-Fix-MangleFilename.patch
@@ -1,0 +1,43 @@
+From 01ab2c4e2eef72a592dfad507350df4b321dcd38 Mon Sep 17 00:00:00 2001
+From: "tamas.lengyel@intel.com" <Tamas K Lengyel>
+Date: Thu, 25 Jul 2024 13:01:18 +0000
+Subject: [PATCH] Fix Bug in UdfDxe MangleFilename
+
+Fixes oss-fuzz issue #68623: edk2:TestFileName: Heap-buffer-overflow in MangleFileName
+
+==33064==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x5210000028fe at pc 0x0000005997ee bp 0x7fffb936d9d0 sp 0x7fffb936d9c8
+READ of size 2 at 0x5210000028fe thread T0
+SCARINESS: 14 (2-byte-read-heap-buffer-overflow)
+    #0 0x5997ed in MangleFileName edk2/MdeModulePkg/Universal/Disk/UdfDxe/FileName.c:186:19
+    #1 0x5969f4 in LLVMFuzzerTestOneInput hbfa-fl/HBFA/UefiHostFuzzTestPkg/Library/ToolChainHarnessLib/ToolChainHarnessLib.c:146:3
+
+Signed-off-by: Tamas K Lengyel <tamas.lengyel@intel.com>
+---
+ MdeModulePkg/Universal/Disk/UdfDxe/FileName.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/MdeModulePkg/Universal/Disk/UdfDxe/FileName.c b/MdeModulePkg/Universal/Disk/UdfDxe/FileName.c
+index 6db34a9c8c..5b2851d77d 100644
+--- a/MdeModulePkg/Universal/Disk/UdfDxe/FileName.c
++++ b/MdeModulePkg/Universal/Disk/UdfDxe/FileName.c
+@@ -156,7 +156,7 @@ MangleFileName (
+           TempFileName = ExcludeTrailingBackslashes (TempFileName);
+           ReplaceLeft (FileName, TempFileName);
+           break;
+-        case '.':
++        case L'.':
+           if ((*(FileName - 1) != L'\\') && ((*(FileName + 2) != L'\\') ||
+                                              (*(FileName + 2) != L'\0')))
+           {
+@@ -183,7 +183,7 @@ MangleFileName (
+           } else {
+             if (*(FileName + 2) != L'\0') {
+               ReplaceLeft (TempFileName, FileName + 3);
+-              if (*(TempFileName - 1) == L'\\') {
++              if (TempFileName - 1 >= FileNameSavedPointer && *(TempFileName - 1) == L'\\') {
+                 FileName = TempFileName;
+                 ExcludeTrailingBackslashes (TempFileName - 1);
+                 TempFileName = FileName;
+-- 
+2.34.1
+

--- a/edk2-bugfixes/0001-Fix-TranslateBmpToGopBlt.patch
+++ b/edk2-bugfixes/0001-Fix-TranslateBmpToGopBlt.patch
@@ -1,0 +1,83 @@
+From 244f5a72fbcbed2a4a5ce301e2ea96f84a13de84 Mon Sep 17 00:00:00 2001
+From: "tamas.lengyel@intel.com" <Tamas K Lengyel>
+Date: Fri, 26 Jul 2024 13:27:54 +0000
+Subject: [PATCH] Fix TranslateBmpToGopBlt
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fixes oss-fuzz issue #68646: Heap-buffer-overflow READ 1 · TranslateBmpToGopBlt
+
+==41962==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x5190000004b4 at pc 0x00000059b3c7 bp 0x7ffcb6f14150 sp 0x7ffcb6f14148
+READ of size 1 at 0x5190000004b4 thread T0
+SCARINESS: 22 (1-byte-read-heap-buffer-overflow-far-from-bounds)
+    #0 0x59b3c6 in TranslateBmpToGopBlt edk2/MdeModulePkg/Library/BaseBmpSupportLib/BmpSupportLib.c:387:44
+    #1 0x596bdd in RunTestHarness hbfa-fl/HBFA/UefiHostFuzzTestCasePkg/TestCase/MdeModulePkg/Library/BaseBmpSupportLib/TestBmpSupportLib.c:57:3
+
+Signed-off-by: Tamas K Lengyel <tamas.lengyel@intel.com>
+---
+ .../Library/BaseBmpSupportLib/BmpSupportLib.c | 44 +++++++++----------
+ 1 file changed, 21 insertions(+), 23 deletions(-)
+
+diff --git a/MdeModulePkg/Library/BaseBmpSupportLib/BmpSupportLib.c b/MdeModulePkg/Library/BaseBmpSupportLib/BmpSupportLib.c
+index c5e885d7a6..590c83703e 100644
+--- a/MdeModulePkg/Library/BaseBmpSupportLib/BmpSupportLib.c
++++ b/MdeModulePkg/Library/BaseBmpSupportLib/BmpSupportLib.c
+@@ -232,33 +232,31 @@ TranslateBmpToGopBlt (
+   //
+   Image       = BmpImage;
+   BmpColorMap = (BMP_COLOR_MAP *)(Image + sizeof (BMP_IMAGE_HEADER));
+-  if (BmpHeader->ImageOffset < sizeof (BMP_IMAGE_HEADER)) {
++  if (BmpHeader->ImageOffset <= sizeof (BMP_IMAGE_HEADER)) {
+     return RETURN_UNSUPPORTED;
+   }
+ 
+-  if (BmpHeader->ImageOffset > sizeof (BMP_IMAGE_HEADER)) {
+-    switch (BmpHeader->BitPerPixel) {
+-      case 1:
+-        ColorMapNum = 2;
+-        break;
+-      case 4:
+-        ColorMapNum = 16;
+-        break;
+-      case 8:
+-        ColorMapNum = 256;
+-        break;
+-      default:
+-        ColorMapNum = 0;
+-        break;
+-    }
++  switch (BmpHeader->BitPerPixel) {
++    case 1:
++      ColorMapNum = 2;
++      break;
++    case 4:
++      ColorMapNum = 16;
++      break;
++    case 8:
++      ColorMapNum = 256;
++      break;
++    default:
++      ColorMapNum = 0;
++      break;
++  }
+ 
+-    //
+-    // BMP file may has padding data between the bmp header section and the
+-    // bmp data section.
+-    //
+-    if (BmpHeader->ImageOffset - sizeof (BMP_IMAGE_HEADER) < sizeof (BMP_COLOR_MAP) * ColorMapNum) {
+-      return RETURN_UNSUPPORTED;
+-    }
++  //
++  // BMP file may has padding data between the bmp header section and the
++  // bmp data section.
++  //
++  if (BmpHeader->ImageOffset - sizeof (BMP_IMAGE_HEADER) < sizeof (BMP_COLOR_MAP) * ColorMapNum) {
++    return RETURN_UNSUPPORTED;
+   }
+ 
+   //
+-- 
+2.34.1
+


### PR DESCRIPTION
Fixes oss-fuzz issue #68623: edk2:TestFileName: Heap-buffer-overflow in MangleFileName

```
==33064==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x5210000028fe at pc 0x0000005997ee bp 0x7fffb936d9d0 sp 0x7fffb936d9c8 READ of size 2 at 0x5210000028fe thread T0
SCARINESS: 14 (2-byte-read-heap-buffer-overflow)
    #0 0x5997ed in MangleFileName edk2/MdeModulePkg/Universal/Disk/UdfDxe/FileName.c:186:19
    #1 0x5969f4 in LLVMFuzzerTestOneInput hbfa-fl/HBFA/UefiHostFuzzTestPkg/Library/ToolChainHarnessLib/ToolChainHarnessLib.c:146:3
```

Fixes oss-fuzz issue #68646: Heap-buffer-overflow READ 1 · TranslateBmpToGopBlt

```
==41962==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x5190000004b4 at pc 0x00000059b3c7 bp 0x7ffcb6f14150 sp 0x7ffcb6f14148
READ of size 1 at 0x5190000004b4 thread T0
SCARINESS: 22 (1-byte-read-heap-buffer-overflow-far-from-bounds)
    #0 0x59b3c6 in TranslateBmpToGopBlt edk2/MdeModulePkg/Library/BaseBmpSupportLib/BmpSupportLib.c:387:44
    #1 0x596bdd in RunTestHarness hbfa-fl/HBFA/UefiHostFuzzTestCasePkg/TestCase/MdeModulePkg/Library/BaseBmpSupportLib/TestBmpSupportLib.c:57:3