### PR TITLE
fix: update HBFA_PATH to use os.path.abspath

### DIFF
--- a/HBFA/UefiHostTestTools/RunAFL.py
+++ b/HBFA/UefiHostTestTools/RunAFL.py
@@ -32,7 +32,7 @@ elif SysType == "Linux":
 workspace = ''
 
 # HBFA package path
-HBFA_PATH = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+HBFA_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # Conf directory
 Conf_Path = os.path.join(HBFA_PATH, 'UefiHostFuzzTestPkg', 'Conf')


### PR DESCRIPTION
abspath gives an absolute path without resolving symlinks, If code is placed in folders containing symlinks AFL run fails with below error

build.py...
 : error F002: Module for [X64] is not a component of active platform. Please make sure that the ARCH and inf file path are given in the same as in