### PR TITLE
fix: add null check for HobStart in GetNextHob function

### DIFF
--- a/HBFA/UefiHostTestPkg/Library/HobLibHost/HobLibHost.c
+++ b/HBFA/UefiHostTestPkg/Library/HobLibHost/HobLibHost.c
@@ -91,6 +91,7 @@ GetNextHob (
 {
   EFI_PEI_HOB_POINTERS  Hob;
 
+  assert (HobStart != NULL);
   Hob.Raw = (UINT8 *) HobStart;
   //
   // Parse the HOB list until end of list or matching type is found.


### PR DESCRIPTION
Edk2 source have the check, during fuzzing created a false positive.