### PR TITLE
OSS-Fuzz: edk2: Fix build by adding missing library

### DIFF
--- a/HBFA/UefiHostFuzzTestCasePkg/UefiHostFuzzTestCasePkg.dsc
+++ b/HBFA/UefiHostFuzzTestCasePkg/UefiHostFuzzTestCasePkg.dsc
@@ -141,6 +141,7 @@
   UefiHostFuzzTestCasePkg/TestCase/SecurityPkg/Library/Tpm2CommandLib/TestTpm2CommandLib.inf {
     <LibraryClasses>
       Tpm2CommandLib|SecurityPkg/Library/Tpm2CommandLib/Tpm2CommandLib.inf
+      Tpm2HelpLib|SecurityPkg/Library/Tpm2HelpLib/Tpm2HelpLib.inf
       Tpm2DeviceLib|UefiHostFuzzTestCasePkg/TestStub/Tpm2DeviceLibStub/Tpm2DeviceLibStub.inf
       Tpm2DeviceStubLib|UefiHostFuzzTestCasePkg/TestStub/Tpm2DeviceLibStub/Tpm2DeviceLibStub.inf
   }


### PR DESCRIPTION
This PR fixes the configuration to include a missing library class which causes the OSS-Fuzz fuzzing build failed for the edk2 project.